### PR TITLE
Fixed algorithm in fetching personal IDs

### DIFF
--- a/orchestra/datamanager/dashboarddata.cpp
+++ b/orchestra/datamanager/dashboarddata.cpp
@@ -88,7 +88,8 @@ entity::Employee DashboardDataProvider::getEmployeeInformation(const std::string
             }();
             // Get personal IDs
             [&foundUser]() {
-                for (const db::StackDB::PersonalIdTableItem& e : DATABASE().SELECT_PERSONAL_ID_TABLE()) {
+                for (const db::StackDB::PersonalIdTableItem& e :
+                     DATABASE().SELECT_PERSONAL_ID_TABLE()) {
                     if (e.ID == foundUser.employeeID()) {
                         foundUser.addPersonalId(e.id_number, e.id_number);
                     }

--- a/orchestra/datamanager/dashboarddata.cpp
+++ b/orchestra/datamanager/dashboarddata.cpp
@@ -88,14 +88,10 @@ entity::Employee DashboardDataProvider::getEmployeeInformation(const std::string
             }();
             // Get personal IDs
             [&foundUser]() {
-                const std::vector<db::StackDB::PersonalIdTableItem>::iterator it =
-                    std::find_if(DATABASE().SELECT_PERSONAL_ID_TABLE().begin(),
-                                 DATABASE().SELECT_PERSONAL_ID_TABLE().end(),
-                                 [&foundUser](const db::StackDB::PersonalIdTableItem &e) {
-                                     return e.ID == foundUser.employeeID();
-                                 });
-                if (it != DATABASE().SELECT_PERSONAL_ID_TABLE().end()) {
-                    foundUser.addPersonalId(it->type, it->id_number);
+                for (const db::StackDB::PersonalIdTableItem& e : DATABASE().SELECT_PERSONAL_ID_TABLE()) {
+                    if (e.ID == foundUser.employeeID()) {
+                        foundUser.addPersonalId(e.id_number, e.id_number);
+                    }
                 }
             }();
             return foundUser;

--- a/orchestra/datamanager/employeedata.cpp
+++ b/orchestra/datamanager/employeedata.cpp
@@ -193,7 +193,8 @@ void EmployeeDataProvider::fillEmployeeDetails(entity::Employee* employee) const
         }();
         // Get personal IDs
         [&employee]() {
-            for (const db::StackDB::PersonalIdTableItem& e : DATABASE().SELECT_PERSONAL_ID_TABLE()) {
+            for (const db::StackDB::PersonalIdTableItem& e :
+                 DATABASE().SELECT_PERSONAL_ID_TABLE()) {
                 if (e.ID == employee->employeeID()) {
                     employee->addPersonalId(e.id_number, e.id_number);
                 }

--- a/orchestra/datamanager/employeedata.cpp
+++ b/orchestra/datamanager/employeedata.cpp
@@ -193,14 +193,10 @@ void EmployeeDataProvider::fillEmployeeDetails(entity::Employee* employee) const
         }();
         // Get personal IDs
         [&employee]() {
-            const std::vector<db::StackDB::PersonalIdTableItem>::iterator it =
-                    std::find_if(DATABASE().SELECT_PERSONAL_ID_TABLE().begin(),
-                                DATABASE().SELECT_PERSONAL_ID_TABLE().end(),
-                                [&employee](const db::StackDB::PersonalIdTableItem& e) {
-                                    return e.ID == employee->employeeID();
-                                });
-            if (it != DATABASE().SELECT_PERSONAL_ID_TABLE().end()) {
-                employee->addPersonalId(it->type, it->id_number);
+            for (const db::StackDB::PersonalIdTableItem& e : DATABASE().SELECT_PERSONAL_ID_TABLE()) {
+                if (e.ID == employee->employeeID()) {
+                    employee->addPersonalId(e.id_number, e.id_number);
+                }
             }
         }();
 }


### PR DESCRIPTION
#74

Issue: Existing algorithm only looks for one personal ID, but the requirement states a person entity can have multiple personal IDs
Fix: Updated the algorithm to search for all personal IDs associated with the employe

### Pull Request Checklist

- [x] I have ensured that my commit message contains the Issue ID.
- [x] I have ensured that my commit message contains the feature/bugfix description.
- [ ] I have updated the documentation accordingly.
- [x] I have ensured my code follows the coding guidelines.
- [x] I have ran lint in my code locally prior to submission.
- [x] I have built my changes in local successfully.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
