### PR TITLE
Fixed crash when selecting an employee index

### DIFF
--- a/config/psinfo.cfg
+++ b/config/psinfo.cfg
@@ -1,2 +1,2 @@
 [CORE]
-version=0.1.8
+version=0.2.0

--- a/core/domain/unittest/test_empmgmt.cpp
+++ b/core/domain/unittest/test_empmgmt.cpp
@@ -88,7 +88,7 @@ TEST_F(TestEmployeeManagement, TestGetEmployeeListWithDataNotInitialized) {
 }
 
 TEST_F(TestEmployeeManagement, TestGetEmployeeData) {
-    const std::string requestedID = "JDO1234";
+    const std::string requestedID = "JDOE123";
     // Fake that the employee data is saved on record
     EXPECT_CALL(*dpMock, getEmployees())
         .WillOnce(Return(
@@ -102,9 +102,9 @@ TEST_F(TestEmployeeManagement, TestGetEmployeeData) {
 }
 
 TEST_F(TestEmployeeManagement, TestGetEmployeeDataNotFound) {
-    const std::string requestedID = "JDO1234";
-    const std::string storedEmployeeID = "PHP5678";
-    // Fake that we only have an employee with ID PHP5678
+    const std::string requestedID = "JDOE123";
+    const std::string storedEmployeeID = "PHIP567";
+    // Fake that we only have an employee with ID PHIP567
     EXPECT_CALL(*dpMock, getEmployees())
         .WillOnce(Return(
             std::vector<entity::Employee>{
@@ -117,7 +117,7 @@ TEST_F(TestEmployeeManagement, TestGetEmployeeDataNotFound) {
 }
 
 TEST_F(TestEmployeeManagement, TestRemoveEmployee) {
-    const std::string requestedID = "JDO1234";
+    const std::string requestedID = "JDOE123";
     // Fake that the employee data is saved on record
     EXPECT_CALL(*dpMock, getEmployees())
         .WillOnce(Return(
@@ -135,9 +135,9 @@ TEST_F(TestEmployeeManagement, TestRemoveEmployee) {
 }
 
 TEST_F(TestEmployeeManagement, TestRemoveEmployeeNotFound) {
-    const std::string requestedID = "JDO1234";
-    const std::string storedEmployeeID = "PHP5678";
-    // Fake that we only have an employee with ID PHP5678
+    const std::string requestedID = "JDOE123";
+    const std::string storedEmployeeID = "PHIP567";
+    // Fake that we only have an employee with ID PHIP567
     EXPECT_CALL(*dpMock, getEmployees())
         .WillOnce(Return(
             std::vector<entity::Employee>{
@@ -150,13 +150,13 @@ TEST_F(TestEmployeeManagement, TestRemoveEmployeeNotFound) {
 
 TEST_F(TestEmployeeManagement, TestRemoveEmployeeWithViewNotInitialized) {
     EmployeeMgmtController dummyController(dpMock, nullptr);
-    ASSERT_EQ(dummyController.remove("JDO1234"), USERSMGMTSTATUS::UNINITIALIZED);
+    ASSERT_EQ(dummyController.remove("JDOE123"), USERSMGMTSTATUS::UNINITIALIZED);
 }
 
 TEST_F(TestEmployeeManagement, TestRemoveEmployeeWithDataNotInitialized) {
     EmployeeMgmtController dummyController(nullptr, viewMock);
     EXPECT_CALL(*viewMock, showDataNotReadyScreen());
-    ASSERT_EQ(dummyController.remove("JDO1234"), USERSMGMTSTATUS::UNINITIALIZED);
+    ASSERT_EQ(dummyController.remove("JDOE123"), USERSMGMTSTATUS::UNINITIALIZED);
 }
 
 TEST_F(TestEmployeeManagement, TestSaveWithNullValidationContainer) {
@@ -218,7 +218,7 @@ TEST_F(TestEmployeeManagement, TestCreateUser) {
 
 TEST_F(TestEmployeeManagement, TestUpdateEmployee) {
     std::map<std::string, std::string> dummyValidationContainer;
-    const std::string requestedID = "JDO1234";
+    const std::string requestedID = "JDOE123";
     SaveEmployeeData employeeData {
              makeValidEmployee(requestedID, false),
              "", &dummyValidationContainer
@@ -242,7 +242,7 @@ TEST_F(TestEmployeeManagement, TestUpdateEmployee) {
 
 TEST_F(TestEmployeeManagement, TestUpdateUser) {
     std::map<std::string, std::string> dummyValidationContainer;
-    const std::string requestedID = "JDO1234";
+    const std::string requestedID = "JDOE123";
     SaveEmployeeData employeeData {
              makeValidEmployee(requestedID, true),
              "1234", &dummyValidationContainer
@@ -266,7 +266,7 @@ TEST_F(TestEmployeeManagement, TestUpdateUser) {
 
 TEST_F(TestEmployeeManagement, TestUpdateEmployeeDataThatIsNotInTheCacheList) {
     std::map<std::string, std::string> dummyValidationContainer;
-    const std::string requestedID = "JDO1234";
+    const std::string requestedID = "JDOE123";
     SaveEmployeeData employeeData {
              makeValidEmployee(requestedID, false),
              "", &dummyValidationContainer

--- a/orchestra/application/screen/backoffice/empmgmtscreen.cpp
+++ b/orchestra/application/screen/backoffice/empmgmtscreen.cpp
@@ -366,9 +366,16 @@ EmployeeMgmtScreen::Options EmployeeMgmtScreen::getUserSelection() {
     } else if (userInput == "0") {
         return Options::LOGOUT;
     } else if (utility::isNumber(userInput)) {
-        // Store user input as the selected index
-        mSelectedEmployeeIndex = std::stoi(userInput);
-        return Options::EMPLOYEE_DETAILS;
+        /*!
+         * If the input is a number, check if we're in the landing screen.
+         * If we're currently in the landing screen, go to employee details.
+         * Otherwise, return invalid.
+        */
+        if (mSelectedEmployeeIndex == 0) {
+            // Store user input as the selected index
+            mSelectedEmployeeIndex = std::stoi(userInput);
+            return Options::EMPLOYEE_DETAILS;
+        }
     } else if (userInput == "c") {
         return Options::EMPLOYEE_CREATE;
     } else if (userInput == "u") {
@@ -385,6 +392,7 @@ bool EmployeeMgmtScreen::action(Options option, std::promise<defines::display>* 
     bool switchScreenIsRequired = false;
     switch (option) {
         case Options::LANDING:
+            // Warning! Consider the recurssion in EMPLOYEE_REMOVE when making changes
             mSelectedEmployeeIndex = 0;  // reset whenever we go to landing
             showLandingScreen();
             break;
@@ -392,8 +400,12 @@ bool EmployeeMgmtScreen::action(Options option, std::promise<defines::display>* 
             invalidOptionSelected();
             break;
         case Options::EMPLOYEE_DETAILS:
-            mSelectedEmployeeIndex > (mEmployeesGUITable.size()) ?
-                invalidOptionSelected() : showEmployeeInformation();
+            if (mSelectedEmployeeIndex > (mEmployeesGUITable.size())) {
+                 mSelectedEmployeeIndex = 0;  // reset while we're in the landing screen
+                invalidOptionSelected();
+            } else {
+                showEmployeeInformation();
+            }
             break;
         case Options::EMPLOYEE_CREATE:
             createEmployee();


### PR DESCRIPTION
xxxx

Issue: While in the employee information screen, we can still select an
employee when inputting their index in the menu. This makes us to go into
an invalid state and crash.

Fix: Added checking to make sure we only interpret the input as an employee
index when we are in the employee management screen.

### Pull Request Checklist

- [x] I have ensured that my commit message contains the Issue ID.
- [x] I have ensured that my commit message contains the feature/bugfix description.
- [ ] I have updated the documentation accordingly.
- [x] I have ensured my code follows the coding guidelines.
- [x] I have ran lint in my code locally prior to submission.
- [x] I have built my changes in local successfully.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
