### PR TITLE
Fixed carriage return issue when reading files in windows

### DIFF
--- a/utility/fileio/fileio.cpp
+++ b/utility/fileio/fileio.cpp
@@ -40,6 +40,9 @@ FileOperationStatus FileIo::read(std::vector<std::string>* container) {
     // read
     std::string buf;
     while (getline(mFile, buf)) {
+#ifdef _WIN32
+        buf.erase(std::remove(buf.begin(), buf.end(), '\r'), buf.end());
+#endif
         container->emplace_back(buf);
     }
     mFile.clear();


### PR DESCRIPTION
Fixes #219

- the issue was Windows uses "\r\n" (carriage return, line feed) to terminate lines
- our file reader reads \r

### Pull Request Checklist

-   [x] I have ensured that my commit message contains the Issue ID.
-   [x] I have ensured that my commit message contains the feature/bugfix description.
-   [ ] I have updated the documentation accordingly.
-   [x] I have ensured my code follows the coding guidelines.
-   [x] I have ran lint in my code locally prior to submission.
-   [ ] I have built my changes in local successfully.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
