### PR TITLE
Change smart pointers to raw pointers

### DIFF
--- a/core/domain/accounting/accountingcontroller.cpp
+++ b/core/domain/accounting/accountingcontroller.cpp
@@ -213,9 +213,12 @@ std::vector<entity::Sale> AccountingController::getVoidSales() {
     return {};
 }
 
-AccountingControllerPtr createAccountingModule(const AccountingDataPtr& data,
-                                               const AccountingViewPtr& view) {
-    return std::make_unique<AccountingController>(data, view);
+AccountingControllerPtr createAccountingModule(const AccountingDataPtr data,
+                                               const AccountingViewPtr view) {
+    if ((!data) || (!view)) {
+        throw std::invalid_argument("Received a nulltpr argument");
+    }
+    return new AccountingController(data, view);
 }
 
 }  // namespace accounting

--- a/core/domain/accounting/interface/accountingiface.hpp
+++ b/core/domain/accounting/interface/accountingiface.hpp
@@ -71,13 +71,13 @@ class AccountingControlInterface {
     virtual std::vector<entity::Sale> getVoidSales() = 0;
 };
 
-typedef std::shared_ptr<AccountingDataInterface> AccountingDataPtr;
-typedef std::shared_ptr<AccountingViewInterface> AccountingViewPtr;
-typedef std::unique_ptr<AccountingControlInterface> AccountingControllerPtr;
+typedef AccountingDataInterface* AccountingDataPtr;
+typedef AccountingViewInterface* AccountingViewPtr;
+typedef AccountingControlInterface* AccountingControllerPtr;
 
 // Lib APIs
 extern "C" CORE_API AccountingControllerPtr createAccountingModule
-                    (const AccountingDataPtr& data, const AccountingViewPtr& view);
+                    (const AccountingDataPtr data, const AccountingViewPtr view);
 
 }  // namespace accounting
 }  // namespace domain

--- a/core/domain/common/basecontroller.hpp
+++ b/core/domain/common/basecontroller.hpp
@@ -34,11 +34,7 @@ namespace domain {
 template <typename DpType, typename ViewType, typename EntityType>
 class BaseController {
  public:
-    explicit BaseController(const std::shared_ptr<DpType> data,
-                            const std::shared_ptr<ViewType> view) {
-        if ((data == nullptr) || (view == nullptr)) {
-           throw std::invalid_argument("Received a nulltpr argument");
-        }
+    explicit BaseController(std::unique_ptr<DpType> data, std::unique_ptr<ViewType> view) {
         mDataProvider = data;
         mView = view;
     }
@@ -57,8 +53,8 @@ class BaseController {
     }
 
     typedef std::pair<std::string, std::function<std::string(const EntityType&)>> Keys;
-    std::shared_ptr<DpType> mDataProvider;
-    std::shared_ptr<ViewType> mView;
+    std::unique_ptr<DpType> mDataProvider;
+    std::unique_ptr<ViewType> mView;
     CacheController<EntityType> mCachedList;
 };
 

--- a/core/domain/customermgmt/customermgmtcontroller.cpp
+++ b/core/domain/customermgmt/customermgmtcontroller.cpp
@@ -161,9 +161,12 @@ CUSTOMERMGMTAPISTATUS CustomerMgmtController::remove(const std::string& id) {
 }
 
 CustomerMgmtCtrlPtr createCustomerMgmtModule(
-                    const CustomerMgmtDataPtr& data,
-                    const CustomerMgmtViewPtr& view) {
-    return std::make_unique<CustomerMgmtController>(data, view);
+                    const CustomerMgmtDataPtr data,
+                    const CustomerMgmtViewPtr view) {
+    if ((!data) || (!view)) {
+        throw std::invalid_argument("Received a nulltpr argument");
+    }
+    return new CustomerMgmtController(data, view);
 }
 
 }  // namespace customermgmt

--- a/core/domain/customermgmt/interface/customermgmtiface.hpp
+++ b/core/domain/customermgmt/interface/customermgmtiface.hpp
@@ -68,13 +68,13 @@ class CustomerManagementControlInterface {
     virtual CUSTOMERMGMTAPISTATUS remove(const std::string& id) = 0;
 };
 
-typedef std::shared_ptr<CustomerManagementDataInterface> CustomerMgmtDataPtr;
-typedef std::shared_ptr<CustomerManagementViewInterface> CustomerMgmtViewPtr;
-typedef std::unique_ptr<CustomerManagementControlInterface> CustomerMgmtCtrlPtr;
+typedef CustomerManagementDataInterface* CustomerMgmtDataPtr;
+typedef CustomerManagementViewInterface* CustomerMgmtViewPtr;
+typedef CustomerManagementControlInterface* CustomerMgmtCtrlPtr;
 
 // Lib APIs
 extern "C" CORE_API CustomerMgmtCtrlPtr createCustomerMgmtModule
-                    (const CustomerMgmtDataPtr& data, const CustomerMgmtViewPtr& view);
+                    (const CustomerMgmtDataPtr data, const CustomerMgmtViewPtr view);
 
 }  // namespace customermgmt
 }  // namespace domain

--- a/core/domain/dashboard/dashboardcontroller.cpp
+++ b/core/domain/dashboard/dashboardcontroller.cpp
@@ -116,9 +116,12 @@ bool DashboardController::isUserValid(const entity::User& userInfo) const {
     return !userInfo.userID().empty();
 }
 
-DashboardControllerPtr createDashboardModule(const DashboardDataPtr& data,
-                                             const DashboardViewPtr& view) {
-    return std::make_unique<DashboardController>(data, view);
+DashboardControllerPtr createDashboardModule(const DashboardDataPtr data,
+                                             const DashboardViewPtr view) {
+    if ((!data) || (!view)) {
+        throw std::invalid_argument("Received a nulltpr argument");
+    }
+    return new DashboardController(data, view);
 }
 
 }  // namespace dashboard

--- a/core/domain/dashboard/interface/dashboardiface.hpp
+++ b/core/domain/dashboard/interface/dashboardiface.hpp
@@ -54,13 +54,13 @@ class DashboardControlInterface {
     virtual entity::Employee getUserDetails(const entity::User& user) = 0;
 };
 
-typedef std::shared_ptr<DashboardDataInterface> DashboardDataPtr;
-typedef std::shared_ptr<DashboardViewInterface> DashboardViewPtr;
-typedef std::unique_ptr<DashboardControlInterface> DashboardControllerPtr;
+typedef DashboardDataInterface* DashboardDataPtr;
+typedef DashboardViewInterface* DashboardViewPtr;
+typedef DashboardControlInterface* DashboardControllerPtr;
 
 // Lib APIs
 extern "C" CORE_API DashboardControllerPtr createDashboardModule
-                    (const DashboardDataPtr& data, const DashboardViewPtr& view);
+                    (const DashboardDataPtr data, const DashboardViewPtr view);
 
 }  // namespace dashboard
 }  // namespace domain

--- a/core/domain/employeemgmt/employeecontroller.cpp
+++ b/core/domain/employeemgmt/employeecontroller.cpp
@@ -223,9 +223,12 @@ ValidationErrors EmployeeMgmtController::validateDetails(const entity::Employee&
     return validationErrors;
 }
 
-EmpMgmtControllerPtr createEmployeeMgmtModule(const EmpMgmtDataPtr& data,
-                                              const EmpMgmtViewPtr& view) {
-    return std::make_unique<EmployeeMgmtController>(data, view);
+EmpMgmtControllerPtr createEmployeeMgmtModule(const EmpMgmtDataPtr data,
+                                              const EmpMgmtViewPtr view) {
+    if ((!data) || (!view)) {
+        throw std::invalid_argument("Received a nulltpr argument");
+    }
+    return new EmployeeMgmtController(data, view);
 }
 
 }  // namespace empmgmt

--- a/core/domain/employeemgmt/interface/employeemgmtiface.hpp
+++ b/core/domain/employeemgmt/interface/employeemgmtiface.hpp
@@ -86,13 +86,13 @@ class EmployeeMgmtControlInterface {
                                                      const std::string& lname) = 0;
 };
 
-typedef std::shared_ptr<EmployeeMgmtDataInterface> EmpMgmtDataPtr;
-typedef std::shared_ptr<EmployeeMgmtViewInterface> EmpMgmtViewPtr;
-typedef std::unique_ptr<EmployeeMgmtControlInterface> EmpMgmtControllerPtr;
+typedef EmployeeMgmtDataInterface* EmpMgmtDataPtr;
+typedef EmployeeMgmtViewInterface* EmpMgmtViewPtr;
+typedef EmployeeMgmtControlInterface* EmpMgmtControllerPtr;
 
 // Lib APIs
 extern "C" CORE_API EmpMgmtControllerPtr createEmployeeMgmtModule
-                    (const EmpMgmtDataPtr& data, const EmpMgmtViewPtr& view);
+                    (const EmpMgmtDataPtr data, const EmpMgmtViewPtr view);
 
 }  // namespace empmgmt
 }  // namespace domain

--- a/core/domain/inventory/interface/inventoryiface.hpp
+++ b/core/domain/inventory/interface/inventoryiface.hpp
@@ -95,13 +95,13 @@ class InventoryControlInterface {
     virtual INVENTORYAPISTATUS removeCategory(const std::string& category) = 0;
 };
 
-typedef std::shared_ptr<InventoryDataInterface> InventoryDataPtr;
-typedef std::shared_ptr<InventoryViewInterface> InventoryViewPtr;
-typedef std::unique_ptr<InventoryControlInterface> InventoryControllerPtr;
+typedef InventoryDataInterface* InventoryDataPtr;
+typedef InventoryViewInterface* InventoryViewPtr;
+typedef InventoryControlInterface* InventoryControllerPtr;
 
 // Lib APIs
 extern "C" CORE_API InventoryControllerPtr createInventoryModule
-                    (const InventoryDataPtr& data, const InventoryViewPtr& view);
+                    (const InventoryDataPtr data, const InventoryViewPtr view);
 
 }  // namespace inventory
 }  // namespace domain

--- a/core/domain/inventory/inventorycontroller.cpp
+++ b/core/domain/inventory/inventorycontroller.cpp
@@ -214,9 +214,12 @@ INVENTORYAPISTATUS InventoryController::removeCategory(const std::string& catego
     return INVENTORYAPISTATUS::SUCCESS;
 }
 
-InventoryControllerPtr createInventoryModule(const InventoryDataPtr& data,
-                                             const InventoryViewPtr& view) {
-    return std::make_unique<InventoryController>(data, view);
+InventoryControllerPtr createInventoryModule(const InventoryDataPtr data,
+                                             const InventoryViewPtr view) {
+    if ((!data) || (!view)) {
+        throw std::invalid_argument("Received a nulltpr argument");
+    }
+    return new InventoryController(data, view);
 }
 
 }  // namespace inventory

--- a/core/domain/pos/interface/posiface.hpp
+++ b/core/domain/pos/interface/posiface.hpp
@@ -34,13 +34,13 @@ class POSControlInterface {
     virtual ~POSControlInterface() = default;
 };
 
-typedef std::shared_ptr<POSDataInterface> POSDataPtr;
-typedef std::shared_ptr<POSViewInterface> POSViewPtr;
-typedef std::unique_ptr<POSControlInterface> POSControllerPtr;
+typedef POSDataInterface* POSDataPtr;
+typedef POSViewInterface* POSViewPtr;
+typedef POSControlInterface* POSControllerPtr;
 
 // Lib APIs
 extern "C" CORE_API POSControllerPtr createPOSModule
-                    (const POSDataPtr& data, const POSViewPtr& view);
+                    (const POSDataPtr data, const POSViewPtr view);
 
 }  // namespace pos
 }  // namespace domain

--- a/core/domain/userlogin/interface/loginiface.hpp
+++ b/core/domain/userlogin/interface/loginiface.hpp
@@ -40,13 +40,13 @@ class LoginControlInterface {
     virtual bool authenticate(const std::string& id, const std::string& pin) = 0;
 };
 
-typedef std::shared_ptr<LoginDataProviderIface> LoginDataPtr;
-typedef std::shared_ptr<LoginViewIface> LoginViewPtr;
-typedef std::unique_ptr<LoginControlInterface> LoginControllerPtr;
+typedef LoginDataProviderIface* LoginDataPtr;
+typedef LoginViewIface* LoginViewPtr;
+typedef LoginControlInterface* LoginControllerPtr;
 
 // Lib APIs
 extern "C" CORE_API LoginControllerPtr createLoginModule
-                    (const LoginDataPtr& dataprovider, const LoginViewPtr& view);
+                    (const LoginDataPtr dataprovider, const LoginViewPtr view);
 
 }  // namespace login
 }  // namespace domain

--- a/core/domain/userlogin/logincontroller.cpp
+++ b/core/domain/userlogin/logincontroller.cpp
@@ -101,9 +101,12 @@ bool LoginController::isUserValid(const entity::User& userInfo) const {
     return !userInfo.userID().empty();
 }
 
-LoginControllerPtr createLoginModule(const LoginDataPtr& dataprovider,
-                                     const LoginViewPtr& view) {
-    return std::make_unique<LoginController>(dataprovider, view);
+LoginControllerPtr createLoginModule(const LoginDataPtr data,
+                                     const LoginViewPtr view) {
+    if ((!data) || (!view)) {
+        throw std::invalid_argument("Received a nulltpr argument");
+    }
+    return new LoginController(data, view);
 }
 
 }  // namespace login

--- a/orchestra/application/screen/backoffice/accountingscreen.cpp
+++ b/orchestra/application/screen/backoffice/accountingscreen.cpp
@@ -56,8 +56,8 @@ AccountingScreen::AccountingScreen()
 
 void AccountingScreen::show(std::promise<defines::display>* promise) {
     mCoreController = domain::accounting::createAccountingModule(
-                    std::make_shared<dataprovider::accounting::AccountingDataProvider>(),
-                    std::make_shared<AccountingScreen>());
+                    new dataprovider::accounting::AccountingDataProvider(),
+                    this);
     // Get the customers from Core then cache the list
     queryTransactionsList();
     // Landing

--- a/orchestra/application/screen/backoffice/customermgmtscreen.cpp
+++ b/orchestra/application/screen/backoffice/customermgmtscreen.cpp
@@ -69,8 +69,8 @@ CustomerMgmtScreen::CustomerMgmtScreen() : mTableHelper({"ID", "First Name", "La
 
 void CustomerMgmtScreen::show(std::promise<defines::display>* promise) {
     mCoreController = domain::customermgmt::createCustomerMgmtModule(
-                    std::make_shared<dataprovider::customermgmt::CustomerDataProvider>(),
-                    std::make_shared<CustomerMgmtScreen>());
+                    new dataprovider::customermgmt::CustomerDataProvider(),
+                    this);
     // Get the customers from Core then cache the list
     queryCustomersList();
     // Landing

--- a/orchestra/application/screen/backoffice/dashboardscreen.cpp
+++ b/orchestra/application/screen/backoffice/dashboardscreen.cpp
@@ -38,8 +38,8 @@ DashboardScreen::DashboardScreen(const std::string& userID) : mUserID(userID) {
 
 void DashboardScreen::show(std::promise<defines::display>* promise) {
     mCoreController = domain::dashboard::createDashboardModule(
-                std::make_shared<dataprovider::dashboard::DashboardDataProvider>(),
-                std::make_shared<DashboardScreen>(mUserID));
+                new dataprovider::dashboard::DashboardDataProvider(),
+                this);
     mCoreController->setCurrentUserId(mUserID);
     mCurrentUser = mCoreController->getCurrentUser();
 

--- a/orchestra/application/screen/backoffice/empmgmtscreen.cpp
+++ b/orchestra/application/screen/backoffice/empmgmtscreen.cpp
@@ -71,8 +71,8 @@ EmployeeMgmtScreen::EmployeeMgmtScreen()
 
 void EmployeeMgmtScreen::show(std::promise<defines::display>* promise) {
     mCoreController = domain::empmgmt::createEmployeeMgmtModule(
-                    std::make_shared<dataprovider::empmgmt::EmployeeDataProvider>(),
-                    std::make_shared<EmployeeMgmtScreen>());
+                    new dataprovider::empmgmt::EmployeeDataProvider(),
+                    this);
     // Get the employees from Core then cache the list
     queryEmployeesList();
     // Landing

--- a/orchestra/application/screen/backoffice/inventoryscreen.cpp
+++ b/orchestra/application/screen/backoffice/inventoryscreen.cpp
@@ -71,8 +71,8 @@ InventoryScreen::InventoryScreen() : mTableHelper({"Product", "Category", "Stock
 
 void InventoryScreen::show(std::promise<defines::display>* promise) {
     mCoreController = domain::inventory::createInventoryModule(
-                    std::make_shared<dataprovider::inventory::InventoryDataProvider>(),
-                    std::make_shared<InventoryScreen>());
+                    new dataprovider::inventory::InventoryDataProvider(),
+                    this);
     // Get the products from Core then cache the list
     queryProductsList();
     // Landing

--- a/orchestra/application/screen/login/loginscreen.cpp
+++ b/orchestra/application/screen/login/loginscreen.cpp
@@ -56,8 +56,7 @@ void LoginScreen::show(std::promise<defines::display>* promise) {
 
 bool LoginScreen::onLogin(const std::string& id, const std::string& pin) {
     domain::login::LoginControllerPtr coreController = domain::login::createLoginModule(
-                            std::make_shared<dataprovider::login::LoginDataProvider>(),
-                            std::make_shared<LoginScreen>());
+                            new dataprovider::login::LoginDataProvider(), this);
     return coreController->authenticate(id, pin);
 }
 


### PR DESCRIPTION
xxxx

Fixes issue in windows where we cannot export C++ object type with extern C on DLLs

Current blocker: BaseController has no way of knowing the dataprovider and view data types. It only knows the interface and this is by design

### Pull Request Checklist

-   [ ] I have ensured that my commit message contains the Issue ID.
-   [ ] I have ensured that my commit message contains the feature/bugfix description.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have ensured my code follows the coding guidelines.
-   [ ] I have ran lint in my code locally prior to submission.
-   [ ] I have built my changes in local successfully.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
